### PR TITLE
Add deployment test based on CRI-O

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: ishvedunov/criproxy-build:0.0.1
+    - image: ishvedunov/criproxy-build:0.0.2
     steps:
     - checkout
     - run:
@@ -35,7 +35,7 @@ jobs:
 
   publish:
     docker:
-    - image: ishvedunov/criproxy-build:0.0.1
+    - image: ishvedunov/criproxy-build:0.0.2
     steps:
     - checkout
     - attach_workspace:
@@ -45,6 +45,45 @@ jobs:
         command: |
           ghr -u Mirantis -delete "${CIRCLE_TAG}" _output/
 
+  deployment-test:
+    environment:
+      DOCKER_VERSION: "17.03.0-ce"
+      KUBECTL_VERSION: "v1.8.4"
+      KUBECTL_SHA1: "8e2314db816b9b4465c5f713c1152cb0603db15e"
+    docker:
+    - image: ishvedunov/criproxy-build:0.0.2
+    steps:
+    - setup-remote-docker
+    - checkout
+    - run:
+        name: Set up the environment
+        command: |
+          # Install Docker client
+          curl -sSL -o "/tmp/docker-${DOCKER_VERSION}.tgz" "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz"
+          tar -xz -C /tmp -f "/tmp/docker-${DOCKER_VERSION}.tgz"
+          mv /tmp/docker/* /usr/bin
+
+          # Start port forwarder
+          ./portforward.sh start
+    - attach_workspace:
+        at: _output
+    - run:
+        name: install kubectl
+        command: |
+          curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
+          echo ${KUBECTL_SHA1} /usr/local/bin/kubectl |sha1sum -c
+          chmod +x /usr/local/bin/kubectl
+    - run:
+        name: Run deployment test script
+        # FIXME: extra "$(...)" is needed because globbing fails
+        # in this CircleCI command for some reason
+        command: |
+          ./portforward.sh 8080&
+          # FIXME: rm this ls -l
+          SKIP_SNAPSHOT=1 \
+            CRIPROXY_DEB="$(echo "${PWD}"/_output/criproxy*nodeps*.deb)" \
+            ./deployment-test.sh
+
 workflows:
   version: 2
   build-test-and-publish:
@@ -52,23 +91,24 @@ workflows:
     - build:
         filters:
           tags:
-            # FIXME: v0.0.2 tag has triggered a CircleCI problem but we can't
-            # delete it yet, to let's exclude it for now. Use simpler
-            # regexp when Virtlet is updated.
-            # only: /^v[0-9].*/
-            only: /v[^0].*|v0\.[^0].*|v0\.0\.[^0][0-9].*|v0\.0\.[3-9]/
+            only: /^v.*/
           branches:
             only: /.*/
-    - publish:
+    - deployment-test:
         requires:
         - build
         filters:
           tags:
-            # FIXME: v0.0.2 tag has triggered a CircleCI problem but we can't
-            # delete it yet, to let's exclude it for now. Use simpler
-            # regexp when Virtlet is updated.
-            # only: /^v[0-9].*/
-            only: /v[^0].*|v0\.[^0].*|v0\.0\.[^0][0-9].*|v0\.0\.[3-9]/
+            only: /^v.*/
+          branches:
+            only: /.*/
+
+    - publish:
+        requires:
+        - build
+        - deployment-test
+        filters:
+          tags:
+            only: /v.*/
           branches:
             ignore: /.*/
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y && \
     apt-get -yy -q install --no-install-recommends --no-install-suggests --fix-missing \
-      dpkg-dev build-essential debhelper dh-systemd && \
+      dpkg-dev build-essential debhelper dh-systemd socat && \
     apt-get upgrade -y && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/deployment-test.sh
+++ b/deployment-test.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+kubectl="${HOME}/.kubeadm-dind-cluster/kubectl"
+dind_script="dind-cluster-v1.8.sh"
+status=0
+
+if [[ ! ${CRIPROXY_DEB_URL:-} && ! ${CRIPROXY_DEB:-} ]]; then
+  echo "Must specify either CRIPROXY_DEB_URL or CRIPROXY_DEB" >&2
+  exit 1
+fi
+
+function step {
+  local OPTS=""
+  if [ "$1" = "-n" ]; then
+    shift
+    OPTS+="-n"
+  fi
+  GREEN="$1"
+  shift
+  if [ -t 2 ] ; then
+    echo -e ${OPTS} "\x1B[97m* \x1B[92m${GREEN}\x1B[39m $*" >&2
+  else
+    echo ${OPTS} "* ${GREEN} $*" >&2
+  fi
+}
+
+function wait-for {
+  local title="$1"
+  local action="$2"
+  local what="$3"
+  shift 3
+  step "Waiting for:" "${title}"
+  while ! "${action}" "${what}" "$@"; do
+    echo -n "." >&2
+    sleep 1
+  done
+  echo "[done]" >&2
+}
+
+function pod-is-gone {
+  local name="$1"
+  if "${kubectl}" get pods "${name}" >&/dev/null; then
+    return 1
+  fi
+}
+
+step "Downloading kubeadm-dind-cluster script"
+rm -f "${dind_script}"
+wget "https://raw.githubusercontent.com/Mirantis/kubeadm-dind-cluster/master/fixed/${dind_script}"
+chmod +x "${dind_script}"
+
+step "Starting kubeadm-dind-cluster"
+
+# Uncomment to have the cluster cleaned up.  Currently we're not doing
+# it as it slows down local debugging.
+# "./${dind_script}" clean use
+
+# Use single-worker cluster so as to have all the pods w/o tolerations
+# scheduled on kube-node-1
+NUM_NODES=1 "./${dind_script}" up
+
+step "Propagating criproxy deb to the node"
+if [[ ${CRIPROXY_DEB_URL:-} ]]; then
+  docker exec kube-node-1 /bin/bash -c "curl -sSL '${CRIPROXY_DEB_URL}' >/criproxy.deb"
+else
+  docker cp "${CRIPROXY_DEB}" kube-node-1:/criproxy.deb
+fi
+
+step "Installing criproxy and cri-o on the node"
+docker exec -i kube-node-1 /bin/bash -s <<EOF
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+apt-get update
+apt-get install -y software-properties-common
+add-apt-repository -y ppa:projectatomic/ppa
+apt-get update
+apt-get install -y cri-o
+
+mkdir -p /etc/sysconfig
+echo 'CRIO_STORAGE_OPTIONS=--root /dind/crio --cgroup-manager cgroupfs' >/etc/sysconfig/crio-storage
+echo 'CRIO_NETWORK_OPTIONS=--cni-config-dir /etc/cni/net.d --cni-plugin-dir /opt/cni/bin' >/etc/sysconfig/crio-network
+systemctl enable crio
+systemctl start crio
+
+dpkg -i /criproxy.deb
+mkdir /etc/systemd/system/criproxy.service.d
+echo -e '[Service]\nExecStart=\nExecStart=/usr/bin/criproxy.sh -v 3 -alsologtostderr -connect /var/run/dockershim.sock,cri.o:/var/run/crio.sock -listen /run/criproxy.sock' >/etc/systemd/system/criproxy.service.d/10-crio.conf
+systemctl daemon-reload
+systemctl restart criproxy
+EOF
+
+step "Starting and verifying busybox pod using CRI-O"
+# Interrupting 'kubectl run' after grep finishes will cause it to exit
+# with a non-zero status, thus '|| true'. It can be considered
+# successful if it displays the message though
+if ! ("${kubectl}" run bbtest-crio --attach \
+        --overrides='{"metadata": {"annotations":{"kubernetes.io/target-runtime":"cri.o"}}}' \
+        --image=cri.o/busybox \
+        --restart=Never -- \
+        /bin/sh -c 'while true; do echo "this-is-crio-pod"; sleep 1; done' || true) |
+        grep --line-buffered -m 1 this-is-crio-pod; then
+  echo "Failed to verify bbtest-crio pod" >&2
+  status=1
+fi
+
+if ! "${kubectl}" logs bbtest-crio | grep -q this-is-crio-pod; then
+  echo "kubectl logs failed on bbtest-crio pod or didn't get this-is-crio-pod in its output" >&2
+  status=1
+fi
+
+if ! docker exec kube-node-1 crioctl pod list | grep bbtest-crio; then
+  echo "Failed to find bbtest-crio pod among CRI-O pods" >&2
+  status=1
+fi
+
+if docker exec kube-node-1 docker ps -a | grep bbtest-crio; then
+  echo "Error: found CRI-O pod's container among docker containers" >&2
+  status=1
+fi
+
+step "Starting and verifying busybox pod using docker"
+# Interrupting 'kubectl run' after grep finishes will cause it to exit
+# with a non-zero status, thus '|| true'. It can be considered
+# successful if it displays the message though
+if ! ("${kubectl}" run bbtest-docker --attach \
+        --image=busybox \
+        --restart=Never -- \
+        /bin/sh -c 'while true; do echo "this-is-docker-pod"; sleep 1; done' || true) |
+        grep --line-buffered -q this-is-docker-pod; then
+  echo "Failed to verify bbtest-docker pod" >&2
+  status=1
+fi
+
+if ! "${kubectl}" logs bbtest-docker | grep -q this-is-docker-pod; then
+  echo "kubectl logs failed on bbtest-docker pod or didn't get this-is-docker-pod in its output" >&2
+  status=1
+fi
+
+if docker exec kube-node-1 crioctl pod list | grep bbtest-docker; then
+  echo "Error: found docker pod in CRI-O pod list" >&2
+  status=1
+fi
+
+if ! docker exec kube-node-1 docker ps -a | grep bbtest-docker; then
+  echo "Didn't find docker pod's container among docker containers" >&2
+  status=1
+fi
+
+step "Verifying pod listing"
+if ! "${kubectl}" get pods | grep bbtest-crio; then
+  echo "Failed to verify bbtest-crio pod" >&2
+  status=1
+fi
+if ! "${kubectl}" get pods | grep bbtest-docker; then
+  echo "Failed to verify bbtest-docker pod" >&2
+  status=1
+fi
+
+step "Deleting bbtest-crio pod"
+"${kubectl}" delete pod bbtest-crio
+wait-for "bbtest-crio pod to be gone" pod-is-gone bbtest-crio
+
+step "Deleting bbtest-docker pod"
+"${kubectl}" delete pod bbtest-docker
+wait-for "bbtest-docker pod to be gone" pod-is-gone bbtest-docker
+
+step "Making sure the cluster is still ok"
+"${kubectl}" get pods --all-namespaces -o wide
+
+exit "${status}"

--- a/portforward.sh
+++ b/portforward.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Portforward hack for CircleCI remote docker
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+if [[ ${1:-} = start ]]; then
+  docker run -d -it \
+         --name portforward --net=host \
+         --entrypoint /bin/sh \
+         bobrik/socat -c "while true; do sleep 1000; done"
+elif [[ ${1} ]]; then
+  socat "TCP-LISTEN:${1},reuseaddr,fork" \
+        EXEC:"'docker exec -i portforward socat STDIO TCP-CONNECT:localhost:${1}'"
+else
+  echo "Must specify either start or the port number" >&2
+  exit 1
+fi


### PR DESCRIPTION
It turned out that getting [CRI-O](http://cri-o.io/) run on [kubeadm-dind-cluster](https://github.com/Mirantis/kubeadm-dind-cluster) is super easy, so I used it to test criproxy in dual runtime mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/criproxy/7)
<!-- Reviewable:end -->
