### PR TITLE
Use -logtostderr instead of -alsologtostderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ the following content (you can also use `systemctl --force edit criproxy.service
 Description=CRI Proxy
 
 [Service]
-ExecStart=/usr/local/bin/criproxy -v 3 -alsologtostderr -connect /var/run/dockershim.sock,virtlet.cloud:/run/virtlet.sock -listen /run/criproxy.sock
+ExecStart=/usr/local/bin/criproxy -v 3 -logtostderr -connect /var/run/dockershim.sock,virtlet.cloud:/run/virtlet.sock -listen /run/criproxy.sock
 Restart=always
 StartLimitInterval=0
 RestartSec=10
@@ -142,7 +142,7 @@ image name / pod id / container id prefixes.
 
 Let's say CRI proxy is started as follows:
 ```
-/usr/bin/criproxy -apiVersion 1.8 -v 3 -alsologtostderr -connect /var/run/dockershim.sock,virtlet.cloud:/run/virtlet.sock -listen /run/criproxy.sock
+/usr/bin/criproxy -apiVersion 1.8 -v 3 -logtostderr -connect /var/run/dockershim.sock,virtlet.cloud:/run/virtlet.sock -listen /run/criproxy.sock
 ```
 
 `-v` option of `criproxy` controls the verbosity here. 0-1 means some
@@ -157,7 +157,7 @@ the log to grow fast. See
 [fixing log throttling](#fixing-log-throttling) below if you're
 starting CRI proxy using systemd with log level set to 3 or higher.
 
-`-alsologtostderr` directs logging output to stderr (it's part of glog configuration)
+`-logtostderr` directs logging output to stderr (it's part of glog configuration)
 
 `-connect /var/run/dockershim.sock,virtlet.cloud:/run/virtlet.sock` specifies the list of
 runtimes that the proxy passes requests to.

--- a/criproxy.service
+++ b/criproxy.service
@@ -3,7 +3,7 @@ Description=CRI Proxy
 Wants=dockershim.service
 
 [Service]
-ExecStart=/usr/bin/criproxy.sh -v 3 -alsologtostderr -connect /var/run/dockershim.sock,virtlet.cloud:/run/virtlet.sock -listen /run/criproxy.sock
+ExecStart=/usr/bin/criproxy.sh -v 3 -logtostderr -connect /var/run/dockershim.sock,virtlet.cloud:/run/virtlet.sock -listen /run/criproxy.sock
 Restart=always
 StartLimitInterval=0
 RestartSec=10

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1513,7 +1513,7 @@ func TestCriProxyInactiveServers(t *testing.T) {
 
 func init() {
 	// FIXME: testing.Verbose() always returns false
-	flag.Set("alsologtostderr", "true")
+	flag.Set("logtostderr", "true")
 	flag.Set("v", "5")
 }
 

--- a/test/deployment-test.sh
+++ b/test/deployment-test.sh
@@ -107,7 +107,7 @@ systemctl start crio
 
 dpkg -i /criproxy.deb
 mkdir /etc/systemd/system/criproxy.service.d
-echo -e '[Service]\nExecStart=\nExecStart=/usr/bin/criproxy.sh -v 3 -alsologtostderr -connect /var/run/dockershim.sock,cri.o:/var/run/crio.sock -listen /run/criproxy.sock' >/etc/systemd/system/criproxy.service.d/10-crio.conf
+echo -e '[Service]\nExecStart=\nExecStart=/usr/bin/criproxy.sh -v 3 -logtostderr -connect /var/run/dockershim.sock,cri.o:/var/run/crio.sock -listen /run/criproxy.sock' >/etc/systemd/system/criproxy.service.d/10-crio.conf
 systemctl daemon-reload
 systemctl restart criproxy
 EOF


### PR DESCRIPTION
Avoid creating logs in `/tmp`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/criproxy/15)
<!-- Reviewable:end -->
