### PR TITLE
Support k8s 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,11 @@ jobs:
     environment:
       K8S_VERSION: "1.10"
 
+  deployment-test-1.11:
+    <<: *deployment_test
+    environment:
+      K8S_VERSION: "1.11"
+
 workflows:
   version: 2
   build-test-and-publish:
@@ -118,6 +123,14 @@ workflows:
             only: /^v.*/
           branches:
             only: /.*/
+    - deployment-test-1.11:
+        requires:
+        - build
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            only: /.*/
 
     - publish:
         requires:
@@ -125,6 +138,7 @@ workflows:
         - deployment-test-1.8
         - deployment-test-1.9
         - deployment-test-1.10
+        - deployment-test-1.11
         filters:
           tags:
             only: /v.*/

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -206,7 +206,15 @@ func (r *RuntimeProxy) clientForImage(image string, noErrorIfNotConnected bool) 
 }
 
 func (r *RuntimeProxy) fixStreamingUrl(url string) string {
-	if strings.HasPrefix(url, "/") {
+	// The URLs provided by dockershim in k8s 1.11+ look like this:
+	// //[::]:35057/cri/exec/tb8rgDBh
+	// These can be passed as-is to the client because they
+	// include the port.
+	// In k8s 1.10-, the following URLs are passed:
+	// /cri/exec/94B_NhGa
+	// These need to be replaced to make exec/attach work with
+	// dockershim.
+	if strings.HasPrefix(url, "/") && !strings.Contains(url, ":") {
 		u := r.streamUrl
 		u.Path = url
 		return u.String()

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -98,7 +98,7 @@ func newProxyTester(t *testing.T, secondSocketSpec string, fakeCriServerMakers [
 	journal := proxytest.NewSimpleJournal()
 	servers := []proxytest.FakeCriServer{
 		fakeCriServerMakers[0](proxytest.NewPrefixJournal(journal, "1/"), "/cri"),
-		fakeCriServerMakers[1](proxytest.NewPrefixJournal(journal, "2/"), "http://192.168.0.5:12345/stream"),
+		fakeCriServerMakers[1](proxytest.NewPrefixJournal(journal, "2/"), "//[::]:12345/stream"),
 	}
 
 	fakeImageNames1 := []string{"image1-1", "image1-2"}
@@ -1054,7 +1054,7 @@ func verifyCRIProxy(t *testing.T, secondSocketSpec string, useNewCriVersionForPr
 				Cmd:         []string{"ls"},
 			},
 			resp: &runtimeapi.ExecResponse{
-				Url: "http://192.168.0.5:12345/stream",
+				Url: "//[::]:12345/stream",
 			},
 			journal: []string{"2/runtime/Exec"},
 		},
@@ -1076,7 +1076,7 @@ func verifyCRIProxy(t *testing.T, secondSocketSpec string, useNewCriVersionForPr
 				ContainerId: containerId2,
 			},
 			resp: &runtimeapi.AttachResponse{
-				Url: "http://192.168.0.5:12345/stream",
+				Url: "//[::]:12345/stream",
 			},
 			journal: []string{"2/runtime/Attach"},
 		},
@@ -1100,7 +1100,7 @@ func verifyCRIProxy(t *testing.T, secondSocketSpec string, useNewCriVersionForPr
 				Port:         []int32{80},
 			},
 			resp: &runtimeapi.PortForwardResponse{
-				Url: "http://192.168.0.5:12345/stream",
+				Url: "//[::]:12345/stream",
 			},
 			journal: []string{"2/runtime/PortForward"},
 		},


### PR DESCRIPTION
kubelet/dockershim is now using dynamic ports for the streaming server and not port 11250
we're trying to set for the dockershim.
- [x] try disabling "fixing" the streaming url (worked)
- [x] make it compatible with k8s 1.10-
- [x] fix the build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/criproxy/19)
<!-- Reviewable:end -->
